### PR TITLE
Feature/sim 966 create alternate magnorm method

### DIFF
--- a/examples/readGalfast_examples/matchGalSEDS.ipynb
+++ b/examples/readGalfast_examples/matchGalSEDS.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:972189dbf4ec53e901d82aa769d588cff51e867e7f89f65edd9c102acfabd4c7"
+  "signature": "sha256:19cd237def5f248c07efc18ef7a3b5999dac19045d279882671bd3d7c5eb5939"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -103,7 +103,8 @@
       "galPhot.loadTotalBandpassesFromFiles(['g', 'r', 'i', 'z', 'y'])\n",
       "\n",
       "#We'll need to set makeCopy to True since we are going to reuse this sedList below\n",
-      "matchRestFrameNames, matchRestMagNorm, matchErrors = matchSED.matchToRestFrame(sedList, catMags, galPhot.bandpassDict,\n",
+      "matchRestFrameNames, matchRestMagNorm, matchErrors = matchSED.matchToRestFrame(sedList, catMags, \n",
+      "                                                                               bandpassDict = galPhot.bandpassDict,\n",
       "                                                                               makeCopy = True)\n",
       "\n",
       "#Show the resulting matches\n",

--- a/python/lsst/sims/photUtils/readGalfast/readGalfast.py
+++ b/python/lsst/sims/photUtils/readGalfast/readGalfast.py
@@ -119,7 +119,7 @@ class readGalfast():
 
     def loadGalfast(self, filenameList, outFileList, sEDPath = None, kuruczPath = None,
                     mltPath = None, wdPath = None, kuruczSubset = None,
-                    mltSubset = None, wdSubset = None, magNormAcc = 1, chunkSize = 10000):
+                    mltSubset = None, wdSubset = None, chunkSize = 10000):
         """
         This is customized for the outputs we currently need for the purposes of consistent output
         It will read in a galfast output file and output desired values for database input into a file
@@ -149,8 +149,6 @@ class readGalfast():
 
         @param [in] wdSubset is a list which provides a subset of the wd files within the
         wd folder that one wants to use
-
-        @param [in] magNormAcc is the number of decimal places within the magNorm result will be accurate.
 
         @param [in] chunkSize is the size of chunks of lines to be read from the catalog at one time.
         """
@@ -348,23 +346,19 @@ class readGalfast():
                 sEDNameK, magNormK, matchErrorK = selectStarSED0.findSED(listDict['kurucz'],
                                                                          sDSSunred[kIn], ra[kIn], dec[kIn],
                                                                          reddening = False,
-                                                                         magNormAcc = magNormAcc,
                                                                          colors = colorDict['kurucz'])
                 sEDNameM, magNormM, matchErrorM = selectStarSED0.findSED(listDict['mlt'],
                                                                          sDSSunred[mIn], ra[mIn], dec[mIn],
                                                                          reddening = False,
-                                                                         magNormAcc = magNormAcc,
                                                                          colors = colorDict['mlt'])
                 sEDNameH, magNormH, matchErrorH = selectStarSED0.findSED(listDict['H'],
                                                                          sDSSunred[hIn], ra[hIn], dec[hIn],
                                                                          reddening = False,
-                                                                         magNormAcc = magNormAcc,
                                                                          colors = colorDict['H'])
                 sEDNameHE, magNormHE, matchErrorHE = selectStarSED0.findSED(listDict['HE'],
                                                                             sDSSunred[heIn], 
                                                                             ra[heIn], dec[heIn],
                                                                             reddening = False,
-                                                                            magNormAcc = magNormAcc,
                                                                             colors = colorDict['HE'])
                 chunkNames = np.empty(readSize, dtype = 'S32')
                 chunkTypes = np.empty(readSize, dtype = 'S8')

--- a/python/lsst/sims/photUtils/readGalfast/rgUtils.py
+++ b/python/lsst/sims/photUtils/readGalfast/rgUtils.py
@@ -26,7 +26,8 @@ class rgBase():
 
         """
         This will find the magNorm value that gives the closest match to the magnitudes of the object
-        using the matched SED.
+        using the matched SED. Uses scipy.optimize.leastsq to find the values of fluxNorm that minimizes
+        the function: ((flux_obs - (fluxNorm*flux_model))/flux_error)**2.
 
         @param [in] objectMags are the magnitude values for the object with extinction matching that of
         the SED object. In the normal case using the selectSED routines above it will be dereddened mags.

--- a/python/lsst/sims/photUtils/readGalfast/selectGalaxySED.py
+++ b/python/lsst/sims/photUtils/readGalfast/selectGalaxySED.py
@@ -15,7 +15,7 @@ class selectGalaxySED(rgGalaxy):
     This class provides methods to match galaxy catalog magnitudes to an SED.
     """
 
-    def matchToRestFrame(self, sedList, catMags, bandpassDict = None, magNormAcc = 2, makeCopy = False):
+    def matchToRestFrame(self, sedList, catMags, mag_error = None, bandpassDict = None, makeCopy = False):
 
         """
         This will find the closest match to the magnitudes of a galaxy catalog if those magnitudes are in
@@ -28,10 +28,11 @@ class selectGalaxySED(rgGalaxy):
         @param [in] catMags is an array of the magnitudes of catalog objects to be matched with a model SED.
         It should be organized so that there is one object's magnitudes along each row.
 
-        @param [in] bandpassDict is an OrderedDict of bandpass objects with which to calculate magnitudes. If left
-        equal to None it will by default load the SDSS [u,g,r,i,z] bandpasses.
+        @param [in] mag_error are provided error values for magnitudes in objectMags. If none provided
+        then this defaults to 1.0. This should be an array of the same size as catMags.
 
-        @param [in] magNormAcc is the number of decimal places within the magNorm result will be accurate.
+        @param [in] bandpassDict is an OrderedDict of bandpass objects with which to calculate magnitudes. 
+        If left equal to None it will by default load the SDSS [u,g,r,i,z] bandpasses.
 
         @param [in] makeCopy indicates whether or not to operate on copies of the SED objects in sedList
         since this method will change the wavelength grid.
@@ -96,8 +97,7 @@ class selectGalaxySED(rgGalaxy):
                 matchedSEDNum = np.nanargmin(distanceArray)
                 sedMatches.append(sedList[matchedSEDNum].name)
                 magNorm = self.calcMagNorm(np.array(catMags[numOn]), sedList[matchedSEDNum],
-                                           galPhot, stepSize = np.power(10, -float(magNormAcc)),
-                                           filtRange = filtNums)
+                                           galPhot, mag_error = mag_error, filtRange = filtNums)
                 magNormMatches.append(magNorm)
                 matchErrors.append(distanceArray[matchedSEDNum]/len(colorRange))
             numOn += 1
@@ -111,7 +111,7 @@ class selectGalaxySED(rgGalaxy):
         return sedMatches, magNormMatches, matchErrors
 
     def matchToObserved(self, sedList, catMags, catRedshifts, catRA = None, catDec = None,
-                        bandpassDict = None, dzAcc = 2, magNormAcc = 2, reddening = True,
+                        mag_error = None, bandpassDict = None, dzAcc = 2, reddening = True,
                         extCoeffs = (4.239, 3.303, 2.285, 1.698, 1.263)):
 
         """
@@ -125,14 +125,17 @@ class selectGalaxySED(rgGalaxy):
         @param [in] sedList is the set of spectral objects from the models SEDs provided by loadBC03
         or other custom loader routine.
 
+        @param [in] catMags is an array of the magnitudes of catalog objects to be matched with a model SED.
+        It should be organized so that there is one object's magnitudes along each row.
+
+        @param [in] catRedshifts is an array of the redshifts of each catalog object.
+
         @param [in] catRA is an array of the RA positions for each catalog object.
 
         @param [in] catDec is an array of the Dec position for each catalog object.
 
-        @param [in] catRedshifts is an array of the redshifts of each catalog object.
-
-        @param [in] catMags is an array of the magnitudes of catalog objects to be matched with a model SED.
-        It should be organized so that there is one object's magnitudes along each row.
+        @param [in] mag_error are provided error values for magnitudes in objectMags. If none provided
+        then this defaults to 1.0. This should be an array of the same size as catMags.
 
         @param [in] bandpassDict is an OrderedDict of bandpass objects with which to calculate magnitudes.
         If left equal to None it will by default load the SDSS [u,g,r,i,z] bandpasses and therefore agree with
@@ -141,8 +144,6 @@ class selectGalaxySED(rgGalaxy):
         @param [in] dzAcc is the number of decimal places you want to use when building the redshift grid.
         For example, dzAcc = 2 will create a grid between the minimum and maximum redshifts with colors
         calculated at every 0.01 change in redshift.
-
-        @param [in] magNormAcc is the number of decimal places within the magNorm result will be accurate.
 
         @param [in] reddening is a boolean that determines whether to correct catalog magnitudes for
         dust in the milky way. By default, it is True.
@@ -245,8 +246,8 @@ class selectGalaxySED(rgGalaxy):
                         matchedSEDNum = np.nanargmin(distanceArray)
                         sedMatches[currentIndex] = sedList[matchedSEDNum].name
                         magNormVal = self.calcMagNorm(np.array(matchMags), sedList[matchedSEDNum], 
-                                                      galPhot, redshift = catRedshifts[currentIndex],
-                                                      stepSize = np.power(10, -float(magNormAcc)),
+                                                      galPhot, mag_error = mag_error,
+                                                      redshift = catRedshifts[currentIndex],
                                                       filtRange = filtNums)
                         magNormMatches[currentIndex] = magNormVal
                         matchErrors[currentIndex] = (distanceArray[0,matchedSEDNum]/len(colorRange))

--- a/python/lsst/sims/photUtils/readGalfast/selectStarSED.py
+++ b/python/lsst/sims/photUtils/readGalfast/selectStarSED.py
@@ -136,8 +136,7 @@ class selectStarSED(rgStar):
                 matchedSEDNum = np.nanargmin(distanceArray)
                 sedMatches.append(sedList[matchedSEDNum].name)
                 magNorm = self.calcMagNorm(objMags[numOn], sedList[matchedSEDNum], 
-                                           starPhot, stepSize = np.power(10, -float(magNormAcc)),
-                                           filtRange = filtNums)
+                                           starPhot, filtRange = filtNums)
                 magNormMatches.append(magNorm)
                 matchErrors.append(distanceArray[matchedSEDNum]/len(colorRange)) #Mean Squared Error
             numOn += 1

--- a/python/lsst/sims/photUtils/readGalfast/selectStarSED.py
+++ b/python/lsst/sims/photUtils/readGalfast/selectStarSED.py
@@ -15,9 +15,9 @@ class selectStarSED(rgStar):
     This class provides a way to match star catalog magntiudes to those of the approriate SED.
     """
 
-    def findSED(self, sedList, catMags, catRA = None, catDec = None, reddening = True, magNormAcc = 2,
-                bandpassDict = None, colors = None, extCoeffs = (4.239, 3.303, 2.285, 1.698, 1.263),
-                makeCopy = False):
+    def findSED(self, sedList, catMags, catRA = None, catDec = None, mag_error = None,
+                reddening = True, bandpassDict = None, colors = None, 
+                extCoeffs = (4.239, 3.303, 2.285, 1.698, 1.263), makeCopy = False):
 
         """
         This will find the SEDs that are the closest match to the magnitudes of a star catalog.
@@ -34,6 +34,9 @@ class selectStarSED(rgStar):
 
         @param [in] catDec is an array of the Dec position for each catalog object.
 
+        @param [in] mag_error are provided error values for magnitudes in objectMags. If none provided
+        then this defaults to 1.0. This should be an array of the same length as objectMags.
+
         @param [in] reddening is a boolean that determines whether to correct catalog magnitudes for 
         dust in the milky way. By default, it is True.
         If true, this uses calculateEBV from EBV.py to find an EBV value for the object's
@@ -42,8 +45,6 @@ class selectStarSED(rgStar):
         in bandpassDict.
         If false, this means it will not run the dereddening procedure.
         
-        @param [in] magNormAcc is the number of decimal places within the magNorm result will be accurate.
-
         @param [in] bandpassDict is an OrderedDict of bandpass objects with which to calculate magnitudes. If left
         equal to None it will by default load the SDSS [u,g,r,i,z] bandpasses and therefore agree with 
         default extCoeffs.

--- a/tests/testReadGalfast.py
+++ b/tests/testReadGalfast.py
@@ -64,8 +64,18 @@ class TestRGBase(unittest.TestCase):
         sedMags = testPhot.manyMagCalc_list(testSED)
         stepSize = 0.001
         testMagNorm = testUtils.calcMagNorm(sedMags, unChangedSED, testPhot, redshift = redVal)
-        
+        #Test adding in mag_errors. If an array of np.ones is passed in we should get same result
+        testMagNormWithErr = testUtils.calcMagNorm(sedMags, unChangedSED, testPhot, 
+                                                   mag_error = np.ones(len(sedMags)), redshift = redVal)
+        #Also need to add in test for filtRange
+        sedMagsIncomp = sedMags
+        sedMagsIncomp[1] = None
+        filtRangeTest = [0, 2, 3, 4]
+        testMagNormFiltRange = testUtils.calcMagNorm(sedMagsIncomp, unChangedSED, testPhot,
+                                                     redshift = redVal, filtRange = filtRangeTest)
         self.assertAlmostEqual(magNorm, testMagNorm, delta = stepSize)
+        self.assertAlmostEqual(magNorm, testMagNormWithErr, delta = stepSize)
+        self.assertAlmostEqual(magNorm, testMagNormFiltRange, delta = stepSize)
 
     def testCalcBasicColors(self):
 

--- a/tests/testReadGalfast.py
+++ b/tests/testReadGalfast.py
@@ -63,8 +63,7 @@ class TestRGBase(unittest.TestCase):
         testSED.multiplyFluxNorm(fluxNorm)
         sedMags = testPhot.manyMagCalc_list(testSED)
         stepSize = 0.001
-        testMagNorm = testUtils.calcMagNorm(sedMags, unChangedSED, testPhot, 
-                                            redshift = redVal, stepSize = stepSize)
+        testMagNorm = testUtils.calcMagNorm(sedMags, unChangedSED, testPhot, redshift = redVal)
         
         self.assertAlmostEqual(magNorm, testMagNorm, delta = stepSize)
 
@@ -431,7 +430,7 @@ class TestSelectGalaxySED(unittest.TestCase):
         testMags[0][2] = np.nan
         testMags[0][4] = np.nan
         testMags[1][1] = np.nan
-        testMatchingResults = testMatching.matchToRestFrame(testSEDList, testMags, magNormAcc = magNormStep,
+        testMatchingResults = testMatching.matchToRestFrame(testSEDList, testMags, 
                                                             bandpassDict = galPhot.bandpassDict)
         self.assertEqual(None, testMatchingResults[0][0])
         self.assertEqual(testSEDNames[1:], testMatchingResults[0][1:])
@@ -446,7 +445,6 @@ class TestSelectGalaxySED(unittest.TestCase):
         errMags[3, :] = None
         errSED = testSEDList[2]
         testMatchingResultsErrors = testMatching.matchToRestFrame([errSED], errMags,
-                                                                  magNormAcc = magNormStep,
                                                                   bandpassDict = galPhot.bandpassDict)
         np.testing.assert_almost_equal(np.array((0.0, 0.4, 2./3.)), testMatchingResultsErrors[2][0:3],
                                        decimal = 3)
@@ -528,8 +526,7 @@ class TestSelectGalaxySED(unittest.TestCase):
         testMagsRedshift[0][4] = np.nan
         testMagsRedshift[1][1] = np.nan
         testMatchingRedshift = testMatching.matchToObserved(testSEDList, testMagsRedshift, testRedshifts,
-                                                            dzAcc = 3, magNormAcc = magNormStep,
-                                                            reddening = False,
+                                                            dzAcc = 3, reddening = False,
                                                             bandpassDict = galPhot.bandpassDict)
 
         self.assertEqual(testSEDNames, testNoExtNoRedshift[0])
@@ -551,7 +548,6 @@ class TestSelectGalaxySED(unittest.TestCase):
         errMags[3, :] = None
         errSED = testSEDList[2]
         testMatchingResultsErrors = testMatching.matchToObserved([errSED], errMags, errRedshifts,
-                                                                 magNormAcc = magNormStep,
                                                                  reddening = False,
                                                                  bandpassDict = galPhot.bandpassDict)
         np.testing.assert_almost_equal(np.array((0.0, 0.4, 2./3.)), testMatchingResultsErrors[2][0:3],
@@ -678,16 +674,14 @@ class TestSelectStarSED(unittest.TestCase):
                 nanMags[0][2] = np.nan
                 nanMags[0][3] = np.nan
                 nanMags[1][1] = np.nan
-                testMatchingResults = testMatching.findSED(typeList, nanMags,
-                                                           magNormAcc = magNormStep, reddening = False)
+                testMatchingResults = testMatching.findSED(typeList, nanMags, reddening = False)
                 self.assertEqual(None, testMatchingResults[0][0])
                 self.assertEqual(names[1:], testMatchingResults[0][1:])
                 self.assertEqual(None, testMatchingResults[1][0])
                 np.testing.assert_almost_equal(magNorms[1:], testMatchingResults[1][1:], 
                                                decimal = magNormStep)
             else:
-                testMatchingResults = testMatching.findSED(typeList, mags,
-                                                           magNormAcc = magNormStep, reddening = False)
+                testMatchingResults = testMatching.findSED(typeList, mags, reddening = False)
                 self.assertEqual(names, testMatchingResults[0])
                 np.testing.assert_almost_equal(magNorms, testMatchingResults[1], decimal = magNormStep)
 
@@ -698,8 +692,7 @@ class TestSelectStarSED(unittest.TestCase):
         errMags[2, 3] += 1. #Total MSE will be 2/(2 colors) = 1.0
         errMags[3, :] = None
         errSED = testSEDList[0][0]
-        testMatchingResultsErrors = testMatching.findSED([errSED], errMags, magNormAcc = magNormStep,
-                                                         reddening = False)
+        testMatchingResultsErrors = testMatching.findSED([errSED], errMags, reddening = False)
         np.testing.assert_almost_equal(np.array((0.0, 0.5, 1.0)), testMatchingResultsErrors[2][0:3], 
                                        decimal = 3)
         self.assertEqual(None, testMatchingResultsErrors[2][3])


### PR DESCRIPTION
I've rewritten calcMagNorm to minimize the error function: E = \sum_i ((Norm * unnormed_flux_i - object_flux_i)/flux_error_i)^2. Using scipy.optimize.leastsq has also let to a speed up of ~9X.