### PR TITLE
Update tests per CatalogDBObject API change

### DIFF
--- a/tests/testCosmology.py
+++ b/tests/testCosmology.py
@@ -495,8 +495,7 @@ class CosmologyMixinUnitTest(unittest.TestCase):
         """
         Does a catalog get written?
         """
-        address = 'sqlite:///' + self.dbName
-        dbObj = myTestGals(address=address)
+        dbObj = myTestGals(database=self.dbName)
         cat = cosmologicalGalaxyCatalog(dbObj)
         cat.write_catalog(self.catName)
 
@@ -504,8 +503,7 @@ class CosmologyMixinUnitTest(unittest.TestCase):
         """
         Does cosmologicalDistanceModulus get properly applied
         """
-        address = 'sqlite:///' + self.dbName
-        dbObj = myTestGals(address=address)
+        dbObj = myTestGals(database=self.dbName)
         cosmoCat = cosmologicalGalaxyCatalog(dbObj)
         controlCat = absoluteGalaxyCatalog(dbObj)
         cosmoIter = cosmoCat.iter_catalog(chunk_size=self.dbSize)

--- a/tests/testPhotometry.py
+++ b/tests/testPhotometry.py
@@ -44,8 +44,8 @@ class variabilityUnitTest(unittest.TestCase):
                             m5=[23.9, 25.0, 24.7, 24.0, 23.3, 22.1],
                             bandpassName=['u', 'g', 'r', 'i', 'z', 'y'])
 
-        self.galaxy = myTestGals(address='sqlite:///PhotometryTestDatabase.db')
-        self.star = myTestStars(address='sqlite:///PhotometryTestDatabase.db')
+        self.galaxy = myTestGals(database='PhotometryTestDatabase.db')
+        self.star = myTestStars(database='PhotometryTestDatabase.db')
 
     def tearDown(self):
         del self.galaxy
@@ -97,8 +97,8 @@ class photometryUnitTest(unittest.TestCase):
                             boundType='circle',unrefractedRA=200.0,unrefractedDec=-30.0,
                             boundLength=1.0, m5 = 25.0)
 
-        self.galaxy = myTestGals(address='sqlite:///PhotometryTestDatabase.db')
-        self.star = myTestStars(address='sqlite:///PhotometryTestDatabase.db')
+        self.galaxy = myTestGals(database='PhotometryTestDatabase.db')
+        self.star = myTestStars(database='PhotometryTestDatabase.db')
 
     def tearDown(self):
         del self.galaxy

--- a/tests/testSetupRoutines.py
+++ b/tests/testSetupRoutines.py
@@ -68,10 +68,6 @@ class testStarDBObject(CatalogDBObject):
 
 class testGalaxyDBObject(CatalogDBObject):
 
-    #: This is the default address.  Simply change this in the class definition for other
-    #: endpoints.
-    dbAddress = "mssql+pymssql://LSST-2:L$$TUser@fatboy.npl.washington.edu:1433/LSST"
-
     #: This is the base table for the galaxies
     #tableid = 'final_clone_db'
     tableid = 'galaxy'
@@ -119,6 +115,7 @@ class testGalaxyDBObject(CatalogDBObject):
 class InstanceCatalogSetupUnittest(unittest.TestCase):
 
     def setUp(self):
+        self.driver = 'sqlite'
         self.StarDBName = 'setupTestStars.db'
         self.GalaxyDBName = 'setupTestGalaxies.db'
         if os.path.exists(self.StarDBName):
@@ -141,8 +138,8 @@ class InstanceCatalogSetupUnittest(unittest.TestCase):
                            unrefractedDec=self.unrefractedDec,
                            radius=self.radius)
 
-        self.starDBObj = testStarDBObject(address='sqlite:///' + self.StarDBName)
-        self.galaxyDBObj = testGalaxyDBObject(address='sqlite:///' + self.GalaxyDBName)
+        self.starDBObj = testStarDBObject(driver=self.driver, database= self.StarDBName)
+        self.galaxyDBObj = testGalaxyDBObject(driver=self.driver, database=self.GalaxyDBName)
 
         self.obs_metadata = ObservationMetaData(unrefractedRA=self.unrefractedRA,
                                                 unrefractedDec=self.unrefractedDec,

--- a/tests/testVariability.py
+++ b/tests/testVariability.py
@@ -311,7 +311,8 @@ def makeAgnTable(size=100, **kwargs):
     conn.close()
 
 class variabilityDB(CatalogDBObject):
-    dbAddress = 'sqlite:///VariabilityTestDatabase.db'
+    driver = 'sqlite'
+    database = 'VariabilityTestDatabase.db'
     idColKey = 'varsimobjid'
     columns = [('id', 'varsimobjid', int),
                ('sedFilename', 'sedfilename', str, 40),


### PR DESCRIPTION
CatalogDBObject requires as input driver/database names instead of addresses

Scott, I realized that testSetupRoutines didn't depend on the UW database after all. The hardcoded connection string just got replaced anyway. I left this test in this package.