### PR TITLE
Bugfix/sim 1162/fix noise units

### DIFF
--- a/python/lsst/sims/photUtils/Bandpass.py
+++ b/python/lsst/sims/photUtils/Bandpass.py
@@ -441,6 +441,39 @@ class Bandpass:
         Pass into this function the bandpass, hardware only of bandpass, and sky sed objects.
         The exposure time, nexp, readnoise, darkcurrent, gain,
         seeing and platescale are also necessary.
+
+        @param [in] skysed is an instantiation of the Sed class representing
+        the emission spectrum of the sky
+
+        @param [in] hardware is an instantiation of the Bandpass class
+        representing the throughput of the system hardware
+
+        @param [in] expTime is the duration of each exposure in seconds
+        (default 15)
+
+        @param [in] nexp is the total number of exposures
+        (default 2)
+
+        @param [in] readnoise in electrons per pixel per exposure
+        (default 5)
+
+        @param [in] darkcurrent in electrons per pixel per second
+        (default 0.2)
+
+        @param [in] othernoise in electrons per pixel per second
+        (default 4.69)
+
+        @param [in] seeing in arcseconds
+        (default 0.7)
+
+        @param [in] plateScale in arcseconds per pixel
+        (default 0.2)
+
+        @param [in] gain in electrons per ADU
+        (default 2.3)
+
+        @param [in] eff area is the effective area of the telescope in cm^2
+        (default is for 6.5 meter diameter)
         """
         #This comes from equation 45 of the SNR document (v1.2, May 2010)
         #www.astro.washington.edu/users/ivezic/Astr511/LSST_SNRdoc.pdf

--- a/python/lsst/sims/photUtils/Bandpass.py
+++ b/python/lsst/sims/photUtils/Bandpass.py
@@ -442,6 +442,10 @@ class Bandpass:
         The exposure time, nexp, readnoise, darkcurrent, gain,
         seeing and platescale are also necessary.
 
+        Note: default parameters are defined in
+
+        sims_photUtils/python/lsst/sims/photUtils/photometricDefaults.py
+
         @param [in] skysed is an instantiation of the Sed class representing
         the emission spectrum of the sky
 
@@ -449,31 +453,22 @@ class Bandpass:
         representing the throughput of the system hardware
 
         @param [in] expTime is the duration of each exposure in seconds
-        (default 15)
 
         @param [in] nexp is the total number of exposures
-        (default 2)
 
         @param [in] readnoise in electrons per pixel per exposure
-        (default 5)
 
         @param [in] darkcurrent in electrons per pixel per second
-        (default 0.2)
 
         @param [in] othernoise in electrons per pixel per second
-        (default 4.69)
 
         @param [in] seeing in arcseconds
-        (default 0.7)
 
         @param [in] plateScale in arcseconds per pixel
-        (default 0.2)
 
         @param [in] gain in electrons per ADU
-        (default 2.3)
 
         @param [in] eff area is the effective area of the telescope in cm^2
-        (default is for 6.5 meter diameter)
         """
         #This comes from equation 45 of the SNR document (v1.2, May 2010)
         #www.astro.washington.edu/users/ivezic/Astr511/LSST_SNRdoc.pdf

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -1035,6 +1035,10 @@ class Sed(object):
         seeing / expTime, calculates the SNR with optimal PSF extraction
         assuming a double-gaussian PSF.
 
+        Note: default parameters are defined in
+
+        sims_photUtils/python/lsst/sims/photUtils/photometricDefaults.py
+
         @param [in] totalbandpass is an instantiation of the Bandpass class
         representing the total throughput (system + atmosphere)
 
@@ -1045,31 +1049,22 @@ class Sed(object):
         representing just the throughput of the system hardware.
 
         @param [in] readnoise in electrons per pixel per exposure
-        (default 5)
 
         @param [in] darkcurrent in electrons per pixel per second
-        (default 0.2)
 
         @param [in] othernoise in electrons per pixel per exposure
-        (default 4.69)
 
         @param [in] seeing in arcseconds
-        (default 0.7)
 
         @param [in] effarea is effective area of the telescope in cm^2
-        (default is for 6.5 meter diameter)
 
         @param [in] expTime is exposure time in seconds
-        (default 15)
 
         @param [in] nexp is number of exposures
-        (default 2)
 
         @param [in] plateScale in arcseconds per pixel
-        (default 0.2)
 
         @param [in] gain in electrons per ADU
-        (default 2.3)
 
         @param [in] verbose is a boolean
 

--- a/python/lsst/sims/photUtils/noiseUtilities.py
+++ b/python/lsst/sims/photUtils/noiseUtilities.py
@@ -28,6 +28,10 @@ def expectedSkyCountsForM5(m5target, totalBandpass,
     provided hardware parameters. Using the resulting Sed in the
     'calcM5' method will return this target value for m5.
 
+    Note: default parameters are defined in
+
+    sims_photUtils/python/lsst/sims/photUtils/photometricDefaults.py
+
     @param [in] the desired value of m5
 
     @param [in] totalBandpass is an instantiation of the Bandpass class
@@ -35,31 +39,22 @@ def expectedSkyCountsForM5(m5target, totalBandpass,
     plus atmosphere)
 
     @param [in] expTime is the duration of a single exposure in seconds
-    (default 15)
 
     @param [in] nexp is the number of exposures being combined
-    (default 2)
 
     @param [in] readnoise in electrons per pixel per exposure
-    (default 5)
 
     @param [in] darkcurrent in electrons per pixel per second
-    (default 0.2)
 
     @param [in] othernoise in electrons per pixel per exposure
-    (default 4.69)
 
     @param [in] seeing in arcseconds
-    (default 0.7)
 
     @param [in] platescale in arcseconds per pixel
-    (default 0.2)
 
     @param [in] gain in electrons per ADU
-    (default 2.3)
 
     @param [in] effarea is the effective area of the primary mirror in square centimeters
-    (default is for a 6.5 meter diameter)
 
     @param [out] returns the expected number of sky counts per pixel
     """
@@ -122,6 +117,10 @@ def setM5(m5target, skysed, totalBandpass, hardware,
     provided hardware parameters. Using the resulting Sed in the
     'calcM5' method will return this target value for m5.
 
+    Note: default parameters are defined in
+
+    sims_photUtils/python/lsst/sims/photUtils/photometricDefaults.py
+
     @param [in] the desired value of m5
 
     @param [in] skysed is an instantiation of the Sed class representing
@@ -135,31 +134,22 @@ def setM5(m5target, skysed, totalBandpass, hardware,
     the throughput due solely to instrumentation.
 
     @param [in] expTime is the duration of a single exposure in seconds
-    (default 15)
 
     @param [in] nexp is the number of exposures being combined
-    (default 2)
 
     @param [in] readnoise in electrons per pixel per exposure
-    (default 5)
 
     @param [in] darkcurrent in electrons per pixel per second
-    (default 2)
 
     @param [in] othernoise in electrons per pixel per exposure
-    (default 4.69)
 
     @param [in] seeing in arcseconds
-    (default 0.7)
 
     @param [in] platescale in arcseconds per pixel
-    (default 0.2)
 
     @param [in] gain in electrons per ADU
-    (default 2.3)
 
     @param [in] effarea is the effective area of the primary mirror in square centimeters
-    (default is for a 6.5 meter diameter)
 
     @param [out] returns an instantiation of the Sed class that is the skysed renormalized
     so that m5 has the desired value.
@@ -208,6 +198,10 @@ def calcM5(skysed, totalBandpass, hardware, expTime=PhotometricDefaults.exptime,
     method (calcM5) calculates the expected m5 value for an observation given
     a sky background Sed and hardware parameters.
 
+    Note: default parameters are defined in
+
+    sims_photUtils/python/lsst/sims/photUtils/photometricDefaults.py
+
     @param [in] skysed is an instantiation of the Sed class representing
     sky emission
 
@@ -219,31 +213,22 @@ def calcM5(skysed, totalBandpass, hardware, expTime=PhotometricDefaults.exptime,
     the throughput due solely to instrumentation.
 
     @param [in] expTime is the duration of a single exposure in seconds
-    (default 15)
 
     @param [in] nexp is the number of exposures being combined
-    (default 2)
 
     @param [in] readnoise in electrons per pixel per exposure
-    (default 5)
 
     @param [in] darkcurrent in electrons per pixel per second
-    (default 0.2)
 
     @param [in] othernoise in electrons per pixel per exposure
-    (default 4.69)
 
     @param [in] seeing in arcseconds
-    (default 0.7)
 
     @param [in] platescale in arcseconds per pixel
-    (default 0.2)
 
     @param [in] gain in electrons per ADU
-    (default 2.3)
 
     @param [in] effarea is the effective area of the primary mirror in square centimeters
-    (default is for a 6.5 meter diameter)
 
     @param [out] returns the value of m5 for the given bandpass and sky SED
     """
@@ -283,6 +268,10 @@ def calcGamma(bandpass, m5,
     signal to noise in equation 5 of the LSST overview paper
     (arXiv:0805.2366)
 
+    Note: default parameters are defined in
+
+    sims_photUtils/python/lsst/sims/photUtils/photometricDefaults.py
+
     @param [in] bandpass is an instantiation of the Bandpass class
     representing the bandpass for which you desire to calculate the
     gamma parameter
@@ -291,13 +280,10 @@ def calcGamma(bandpass, m5,
     in this Bandpass
 
     @param [in] expTime is the duration of a single exposure in seconds
-    (default 15)
 
     @param [in] nexp is the number of exposures being combined
-    (default 2)
 
     @param [in] gain is the number of electrons per ADU
-    (default 2.3)
 
     @param [in] effarea is the effective area of the primary mirror
     in square centimeters (default is for 6.5 meter diameter)
@@ -350,6 +336,10 @@ def calcSNR_gamma(fluxes, bandpasses, m5, gamma=None, sig2sys=None,
     """
     Calculate signal to noise in flux using the model from equation (5) of arXiv:0805.2366
 
+    Note: default parameters are defined in
+
+    sims_photUtils/python/lsst/sims/photUtils/photometricDefaults.py
+
     @param [in] fluxes is a numpy array of fluxes.  Each row is a different bandpass.
     Each column is a different object, i.e. fluxes[i][j] is the flux of the jth object
     in the ith bandpass.
@@ -365,13 +355,10 @@ def calcSNR_gamma(fluxes, bandpasses, m5, gamma=None, sig2sys=None,
     @param [in] sig2sys is the square of the systematic signal to noise ratio.
 
     @param [in] expTime (optional) is the duration of a single exposure in seconds
-    (default 15)
 
     @param [in] nexp (optional) is the number of exposures being combined
-    (default 2)
 
     @param [in] gain (optional) is the number of electrons per ADU
-    (default 2.3)
 
     @param [in] effarea (optional) is the effective area of the primary mirror
     in square centimeters (default is for 6.5 meter diameter)

--- a/python/lsst/sims/photUtils/noiseUtilities.py
+++ b/python/lsst/sims/photUtils/noiseUtilities.py
@@ -35,22 +35,31 @@ def expectedSkyCountsForM5(m5target, totalBandpass,
     plus atmosphere)
 
     @param [in] expTime is the duration of a single exposure in seconds
+    (default 15)
 
     @param [in] nexp is the number of exposures being combined
+    (default 2)
 
-    @param [in] readnoise
+    @param [in] readnoise in electrons per pixel per exposure
+    (default 5)
 
-    @param [in] darkcurrent
+    @param [in] darkcurrent in electrons per pixel per second
+    (default 0.2)
 
-    @param [in] othernoise
+    @param [in] othernoise in electrons per pixel per exposure
+    (default 4.69)
 
     @param [in] seeing in arcseconds
+    (default 0.7)
 
     @param [in] platescale in arcseconds per pixel
+    (default 0.2)
 
     @param [in] gain in electrons per ADU
+    (default 2.3)
 
     @param [in] effarea is the effective area of the primary mirror in square centimeters
+    (default is for a 6.5 meter diameter)
 
     @param [out] returns the expected number of sky counts per pixel
     """
@@ -68,7 +77,10 @@ def expectedSkyCountsForM5(m5target, totalBandpass,
     neff = flatSed.calcNeff(seeing, platescale)
 
     #calculate the square of the noise due to the instrument
-    noise_instr_sq = flatSed.calcInstrNoiseSq(readnoise, darkcurrent, expTime, nexp, othernoise)
+    noise_instr_sq_electrons = flatSed.calcInstrNoiseSqElectrons(readnoise, darkcurrent, expTime, nexp, othernoise)
+
+    #convert to counts
+    noise_instr_sq = noise_instr_sq_electrons/(gain*gain)
 
     #now solve equation 41 of the SNR document for the neff * sigma_total^2 term
     #given snr=5 and counts as calculated above
@@ -123,22 +135,31 @@ def setM5(m5target, skysed, totalBandpass, hardware,
     the throughput due solely to instrumentation.
 
     @param [in] expTime is the duration of a single exposure in seconds
+    (default 15)
 
     @param [in] nexp is the number of exposures being combined
+    (default 2)
 
-    @param [in] readnoise
+    @param [in] readnoise in electrons per pixel per exposure
+    (default 5)
 
-    @param [in] darkcurrent
+    @param [in] darkcurrent in electrons per pixel per second
+    (default 2)
 
-    @param [in] othernoise
+    @param [in] othernoise in electrons per pixel per exposure
+    (default 4.69)
 
     @param [in] seeing in arcseconds
+    (default 0.7)
 
     @param [in] platescale in arcseconds per pixel
+    (default 0.2)
 
     @param [in] gain in electrons per ADU
+    (default 2.3)
 
     @param [in] effarea is the effective area of the primary mirror in square centimeters
+    (default is for a 6.5 meter diameter)
 
     @param [out] returns an instantiation of the Sed class that is the skysed renormalized
     so that m5 has the desired value.
@@ -198,22 +219,31 @@ def calcM5(skysed, totalBandpass, hardware, expTime=PhotometricDefaults.exptime,
     the throughput due solely to instrumentation.
 
     @param [in] expTime is the duration of a single exposure in seconds
+    (default 15)
 
     @param [in] nexp is the number of exposures being combined
+    (default 2)
 
-    @param [in] readnoise
+    @param [in] readnoise in electrons per pixel per exposure
+    (default 5)
 
-    @param [in] darkcurrent
+    @param [in] darkcurrent in electrons per pixel per second
+    (default 0.2)
 
-    @param [in] othernoise
+    @param [in] othernoise in electrons per pixel per exposure
+    (default 4.69)
 
     @param [in] seeing in arcseconds
+    (default 0.7)
 
     @param [in] platescale in arcseconds per pixel
+    (default 0.2)
 
     @param [in] gain in electrons per ADU
+    (default 2.3)
 
     @param [in] effarea is the effective area of the primary mirror in square centimeters
+    (default is for a 6.5 meter diameter)
 
     @param [out] returns the value of m5 for the given bandpass and sky SED
     """
@@ -261,13 +291,16 @@ def calcGamma(bandpass, m5,
     in this Bandpass
 
     @param [in] expTime is the duration of a single exposure in seconds
+    (default 15)
 
     @param [in] nexp is the number of exposures being combined
+    (default 2)
 
     @param [in] gain is the number of electrons per ADU
+    (default 2.3)
 
     @param [in] effarea is the effective area of the primary mirror
-    in square centimeters
+    in square centimeters (default is for 6.5 meter diameter)
 
     @param [out] gamma
     """
@@ -332,13 +365,16 @@ def calcSNR_gamma(fluxes, bandpasses, m5, gamma=None, sig2sys=None,
     @param [in] sig2sys is the square of the systematic signal to noise ratio.
 
     @param [in] expTime (optional) is the duration of a single exposure in seconds
+    (default 15)
 
     @param [in] nexp (optional) is the number of exposures being combined
+    (default 2)
 
     @param [in] gain (optional) is the number of electrons per ADU
+    (default 2.3)
 
     @param [in] effarea (optional) is the effective area of the primary mirror
-    in square centimeters
+    in square centimeters (default is for 6.5 meter diameter)
 
     @param [out] snr is a numpy array of the signal to noise ratio corresponding to
     the input fluxes.

--- a/python/lsst/sims/photUtils/photometricDefaults.py
+++ b/python/lsst/sims/photUtils/photometricDefaults.py
@@ -23,9 +23,16 @@ class PhotometricDefaults(object):
     nexp = 2                          # Default number of exposures. (option for methods).
     effarea = numpy.pi*(6.5*100/2.0)**2   # Default effective area of primary mirror. (option for methods).
     gain = 2.3                        # Default gain. (option for method call).
-    rdnoise = 5                       # Default value - readnoise electrons or adu per pixel (per exposure)
-    darkcurrent = 0.2                 # Default value - dark current electrons or adu per pixel per second
-    othernoise = 4.69                 # Default value - other noise electrons or adu per pixel per exposure
+
+    #The quantities below are measured in electrons.
+    #This is taken from the specifications document LSE-30 on Docushare
+    #Section 3.4.2.3 states that the total noise per pixel shall be 12.7 electrons
+    #which these numbers sum to (remember to multply darkcurrent by the number
+    #of seconds in an exposure=15).
+    rdnoise = 5                       # Default value - readnoise electrons per pixel (per exposure)
+    darkcurrent = 0.2                 # Default value - dark current electrons per pixel per second
+    othernoise = 4.69                 # Default value - other noise electrons per pixel per exposure
+
     platescale = 0.2                  # Default value - "/pixel
     seeing = {'u': 0.77, 'g':0.73, 'r':0.70, 'i':0.67, 'z':0.65, 'y':0.63}  # Default seeing values (in ")
 


### PR DESCRIPTION
There was an ambiguity in the units of our noise parameters (readnoise, darkcurrent, and othernoise).  I'm fairly certain that the default values in photometricDefaults.py were/are in electrons (see the comments I added to that file).  However, the method Sed.calcSNR_psf claimed that they needed to be in ADU.  I have tried to fix the code so that it is all consistent with those values being in electrons.  I have updated the docstrings so that users are told they can only provide those values in electrons (before it said they could be either ADU or electrons).