### PR TITLE
bugfix/SIM-1169/igm_unittest_failure

### DIFF
--- a/python/lsst/sims/photUtils/applyIGM.py
+++ b/python/lsst/sims/photUtils/applyIGM.py
@@ -73,7 +73,7 @@ class ApplyIGM(object):
                     self.varLookups[str(zValue)] = np.genfromtxt(str(filesDir + '/VarLookupTable_zSource' + 
                                                                      str(zValue) + '.tbl'))
                 except IOError:
-                    print "Cannot find variance tables."
+                    raise IOError("Cannot find variance tables.")
 
         self.tablesPresent = True
 

--- a/tests/testApplyIGM.py
+++ b/tests/testApplyIGM.py
@@ -38,7 +38,7 @@ class TestApplyIGM(unittest.TestCase):
         testMeanLookupTable = open('MeanLookupTable_zSource1.5.tbl', 'w')
         testMeanLookupTable.write('300.0        0.9999')
         testMeanLookupTable.close()
-        self.assertRaisesRegexp(IOError, "Cannot find variance tables.", testIGM.loadTables(os.getcwd()))
+        self.assertRaisesRegexp(IOError, "Cannot find variance tables.", testIGM.loadTables, os.getcwd())
         os.remove('MeanLookupTable_zSource1.5.tbl')
 
         #Then make sure that the mean lookup tables and var lookup tables all get loaded into proper dicts


### PR DESCRIPTION
Some exception handling code in ApplyIGM.py was not working properly.

For some reason, the stack anaconda was letting us get away with this.  When Jon Swinbank tried to build maf with his own python, he got a unit test failure.

This (two line) pull request fixes that problem.