### PR TITLE
Bugfix/sim 1211/properly sum magnitudes

### DIFF
--- a/python/lsst/sims/photUtils/Photometry.py
+++ b/python/lsst/sims/photUtils/Photometry.py
@@ -587,6 +587,10 @@ class PhotometryGalaxies(PhotometryBase):
             nn += numpy.where(numpy.isnan(agn), 0.0, numpy.power(10, -0.4*(agn - mm_0)))
 
         if baselineType == numpy.ndarray:
+            # according to this link
+            # http://stackoverflow.com/questions/25087769/runtimewarning-divide-by-zero-error-how-to-avoid-python-numpy
+            # we will still get a divide by zero error from log10, but numpy.where will be
+            #circumventing the offending value, so it is probably okay
             return numpy.where(nn>tol, -2.5*numpy.log10(nn) + mm_0, numpy.NaN)
         else:
             if nn>tol:

--- a/python/lsst/sims/photUtils/Photometry.py
+++ b/python/lsst/sims/photUtils/Photometry.py
@@ -570,6 +570,7 @@ class PhotometryGalaxies(PhotometryBase):
                                "either floats or numpy arrays; you appear to have passed %s " % baselineType)
 
         mm_0 = 22.
+        tol = 1.0e-30
 
         if baselineType == numpy.ndarray:
             nn = numpy.zeros(elements)
@@ -586,9 +587,9 @@ class PhotometryGalaxies(PhotometryBase):
             nn += numpy.where(numpy.isnan(agn), 0.0, numpy.power(10, -0.4*(agn - mm_0)))
 
         if baselineType == numpy.ndarray:
-            return numpy.where(nn>0.0, -2.5*numpy.log10(nn) + mm_0, numpy.NaN)
+            return numpy.where(nn>tol, -2.5*numpy.log10(nn) + mm_0, numpy.NaN)
         else:
-            if nn>0.0:
+            if nn>tol:
                 return -2.5*numpy.log10(nn) + mm_0
             else:
                 return numpy.NaN

--- a/python/lsst/sims/photUtils/Photometry.py
+++ b/python/lsst/sims/photUtils/Photometry.py
@@ -550,7 +550,7 @@ class PhotometryGalaxies(PhotometryBase):
                     elements = len(bulge)
             elif not isinstance(bulge, baselineType):
                 raise RuntimeError("All non-None arguments of sum_magnitudes need to be " +
-                                   "of the same time (float or numpy array)")
+                                   "of the same type (float or numpy array)")
 
         elif not isinstance(agn, type(None)):
             if baseLineType == type(None):
@@ -559,7 +559,7 @@ class PhotometryGalaxies(PhotometryBase):
                     elements = len(agn)
             elif not isinstance(agn, baselineType):
                 raise RuntimeError("All non-None arguments of sum_magnitudes need to be " +
-                                   "of the same time (float or numpy array)")
+                                   "of the same type (float or numpy array)")
 
         if baselineType is not float and \
            baselineType is not numpy.ndarray and \

--- a/python/lsst/sims/photUtils/Photometry.py
+++ b/python/lsst/sims/photUtils/Photometry.py
@@ -590,7 +590,7 @@ class PhotometryGalaxies(PhotometryBase):
             # according to this link
             # http://stackoverflow.com/questions/25087769/runtimewarning-divide-by-zero-error-how-to-avoid-python-numpy
             # we will still get a divide by zero error from log10, but numpy.where will be
-            #circumventing the offending value, so it is probably okay
+            # circumventing the offending value, so it is probably okay
             return numpy.where(nn>tol, -2.5*numpy.log10(nn) + mm_0, numpy.NaN)
         else:
             if nn>tol:

--- a/python/lsst/sims/photUtils/Photometry.py
+++ b/python/lsst/sims/photUtils/Photometry.py
@@ -569,7 +569,7 @@ class PhotometryGalaxies(PhotometryBase):
             raise RuntimeError("Arguments of sum_magnitudes need to be " +
                                "either floats or numpy arrays; you appear to have passed %s " % baselineType)
 
-        mm_o = 22.
+        mm_0 = 22.
 
         if baselineType == numpy.ndarray:
             nn = numpy.zeros(elements)
@@ -577,19 +577,19 @@ class PhotometryGalaxies(PhotometryBase):
             nn = 0.0
 
         if disk is not None:
-            nn += numpy.where(numpy.isnan(disk), 0.0, numpy.power(10, (disk - mm_o)/-2.5))
+            nn += numpy.where(numpy.isnan(disk), 0.0, numpy.power(10, -0.4*(disk - mm_0)))
 
         if bulge is not None:
-            nn += numpy.where(numpy.isnan(bulge), 0.0, numpy.power(10, (bulge - mm_o)/-2.5))
+            nn += numpy.where(numpy.isnan(bulge), 0.0, numpy.power(10, -0.4*(bulge - mm_0)))
 
         if agn is not None:
-            nn += numpy.where(numpy.isnan(agn), 0.0, numpy.power(10, (agn - mm_o)/-2.5))
+            nn += numpy.where(numpy.isnan(agn), 0.0, numpy.power(10, -0.4*(agn - mm_0)))
 
         if baselineType == numpy.ndarray:
-            return numpy.where(nn>0.0, -2.5*numpy.log10(nn) + mm_o, numpy.NaN)
+            return numpy.where(nn>0.0, -2.5*numpy.log10(nn) + mm_0, numpy.NaN)
         else:
             if nn>0.0:
-                return -2.5*numpy.log10(nn) + mm_o
+                return -2.5*numpy.log10(nn) + mm_0
             else:
                 return numpy.NaN
 

--- a/python/lsst/sims/photUtils/Photometry.py
+++ b/python/lsst/sims/photUtils/Photometry.py
@@ -577,16 +577,16 @@ class PhotometryGalaxies(PhotometryBase):
             nn = 0.0
 
         if disk is not None:
-            nn+=numpy.power(10, (disk - mm_o)/-2.5)
+            nn += numpy.where(numpy.isnan(disk), 0.0, numpy.power(10, (disk - mm_o)/-2.5))
 
         if bulge is not None:
-            nn+=numpy.power(10, (bulge - mm_o)/-2.5)
+            nn += numpy.where(numpy.isnan(bulge), 0.0, numpy.power(10, (bulge - mm_o)/-2.5))
 
         if agn is not None:
-            nn+=numpy.power(10, (agn - mm_o)/-2.5)
+            nn += numpy.where(numpy.isnan(agn), 0.0, numpy.power(10, (agn - mm_o)/-2.5))
 
         if baselineType == numpy.ndarray:
-            return numpy.array([-2.5*numpy.log10(nnval) + mm_o if nnval>0.0 else numpy.NaN for nnval in nn])
+            return numpy.where(nn>0.0, -2.5*numpy.log10(nn) + mm_o, numpy.NaN)
         else:
             if nn>0.0:
                 return -2.5*numpy.log10(nn) + mm_o

--- a/python/lsst/sims/photUtils/utils/testUtils.py
+++ b/python/lsst/sims/photUtils/utils/testUtils.py
@@ -446,7 +446,7 @@ class cartoonStarsIZ(cartoonStarsOnlyI):
     catalog_type = 'cartoonStarsIR'
     column_outputs = ['id', 'raObserved', 'decObserved', 'cartoon_i', 'cartoon_z']
 
-class cartoonGalaxies(InstanceCatalog,AstrometryGalaxies,EBVmixin,VariabilityGalaxies,cartoonPhotometryGalaxies,testDefaults):
+class cartoonGalaxies(InstanceCatalog, AstrometryGalaxies, EBVmixin, VariabilityGalaxies, cartoonPhotometryGalaxies, testDefaults):
     """
     A catalog of galaxies relying on the cartoon photometry methods (which use non-LSST bandpasses
     and output extra data for use by unit tests)
@@ -457,14 +457,14 @@ class cartoonGalaxies(InstanceCatalog,AstrometryGalaxies,EBVmixin,VariabilityGal
 
     #I need to give it the name of an actual SED file that spans the expected wavelength range
     defSedName = "Inst.80E09.25Z.spec"
-    default_columns = [('sedFilename', defSedName, (str, len(defSedName))) ,
-                       ('sedFilenameAgn', defSedName, (str, len(defSedName))),
-                       ('sedFilenameBulge', defSedName, (str, len(defSedName))),
-                       ('sedFilenameDisk', defSedName, (str, len(defSedName))),
+    default_columns = [('sedFilenameBulge', defSedName, (str,len(defSedName))),
+                       ('sedFilenameDisk', defSedName, (str,len(defSedName))),
+                       ('sedFilenameAgn', defSedName, (str,len(defSedName))),
                        ('glon', 210., float),
                        ('glat', 70., float),
                        ('internalAvBulge',3.1,float),
                        ('internalAvDisk',3.1,float)]
+
 
     def get_galid(self):
         return self.column_by_name('id')
@@ -490,10 +490,9 @@ class cartoonGalaxiesIG(InstanceCatalog,AstrometryGalaxies,EBVmixin,VariabilityG
 
     #I need to give it the name of an actual SED file that spans the expected wavelength range
     defSedName = "Inst.80E09.25Z.spec"
-    default_columns = [('sedFilename', defSedName, (str, len(defSedName))) ,
-                       ('sedFilenameAgn', defSedName, (str, len(defSedName))),
-                       ('sedFilenameBulge', defSedName, (str, len(defSedName))),
-                       ('sedFilenameDisk', defSedName, (str, len(defSedName))),
+    default_columns = [('sedFilenameBulge', defSedName, (str,len(defSedName))),
+                       ('sedFilenameDisk', defSedName, (str,len(defSedName))),
+                       ('sedFilenameAgn', defSedName, (str,len(defSedName))),
                        ('glon', 210., float),
                        ('glat', 70., float),
                        ('internalAvBulge',3.1,float),

--- a/tests/testPhotometry.py
+++ b/tests/testPhotometry.py
@@ -433,8 +433,7 @@ class photometryUnitTest(unittest.TestCase):
         obs_metadata_pointed=ObservationMetaData(mjd=2013.23,
                                                  boundType='circle',unrefractedRA=200.0,unrefractedDec=-30.0,
                                                  boundLength=1.0)
-        obs_metadata_pointed.metadata = {}
-        obs_metadata_pointed.metadata['Opsim_filter'] = 'i'
+
         test_cat=cartoonStars(self.star,obs_metadata=obs_metadata_pointed)
         test_cat.write_catalog("testStarsCartoon.txt")
 
@@ -478,8 +477,7 @@ class photometryUnitTest(unittest.TestCase):
         obs_metadata_pointed=ObservationMetaData(mjd=50000.0,
                                boundType='circle',unrefractedRA=0.0,unrefractedDec=0.0,
                                boundLength=10.0)
-        obs_metadata_pointed.metadata = {}
-        obs_metadata_pointed.metadata['Opsim_filter'] = 'i'
+
         test_cat=cartoonGalaxies(self.galaxy,obs_metadata=obs_metadata_pointed)
         test_cat.write_catalog("testGalaxiesCartoon.txt")
 
@@ -541,8 +539,7 @@ class photometryUnitTest(unittest.TestCase):
         obs_metadata_pointed=ObservationMetaData(mjd=2013.23,
                                                  boundType='circle',unrefractedRA=200.0,unrefractedDec=-30.0,
                                                  boundLength=1.0)
-        obs_metadata_pointed.metadata = {}
-        obs_metadata_pointed.metadata['Opsim_filter'] = 'i'
+
         baseline_cat=cartoonStars(self.star,obs_metadata=obs_metadata_pointed)
         baseline_cat.write_catalog(baselineCatName)
         baselineData = numpy.genfromtxt(baselineCatName, dtype=baselineDtype, delimiter=',')
@@ -590,8 +587,7 @@ class photometryUnitTest(unittest.TestCase):
         obs_metadata_pointed=ObservationMetaData(mjd=50000.0,
                                boundType='circle',unrefractedRA=0.0,unrefractedDec=0.0,
                                boundLength=10.0)
-        obs_metadata_pointed.metadata = {}
-        obs_metadata_pointed.metadata['Opsim_filter'] = 'i'
+
         baseline_cat=cartoonGalaxies(self.galaxy,obs_metadata=obs_metadata_pointed)
         baseline_cat.write_catalog(baselineCatName)
         baselineData = numpy.genfromtxt(baselineCatName, dtype=baselineDtype, delimiter=',')

--- a/tests/testPhotometry.py
+++ b/tests/testPhotometry.py
@@ -177,15 +177,8 @@ class photometryUnitTest(unittest.TestCase):
 
         phot = PhotometryGalaxies()
         test = phot.sum_magnitudes(bulge=bulge, disk=disk, agn=agn)
-        for ix, (tt, aa) in enumerate(zip(test, answer)):
-            if ix<7:
-                msg = 'ix %d tt %e aa %e' % (ix, tt, aa)
-                self.assertAlmostEqual(tt, aa, 10, msg=msg)
-                self.assertTrue(not numpy.isnan(tt))
-            else:
-                self.assertTrue(numpy.isnan(tt))
-                self.assertTrue(numpy.isnan(aa))
 
+        numpy.testing.assert_array_almost_equal(test, answer, decimal=10)
 
         for ix, (bb, dd, aa, truth) in enumerate(zip(bulge, disk, agn, answer)):
             test = phot.sum_magnitudes(bulge=bb, disk=dd, agn=aa)

--- a/tests/testPhotometry.py
+++ b/tests/testPhotometry.py
@@ -106,7 +106,7 @@ class photometryUnitTest(unittest.TestCase):
         del self.star
         del self.obs_metadata
 
-    def testStars(self):
+    def testStarCatalog(self):
         test_cat=testStars(self.star, obs_metadata=self.obs_metadata)
         test_cat.write_catalog("testStarsOutput.txt")
         cat = open("testStarsOutput.txt")
@@ -119,7 +119,7 @@ class photometryUnitTest(unittest.TestCase):
         os.unlink("testStarsOutput.txt")
 
 
-    def testGalaxies(self):
+    def testGalaxyCatalog(self):
         test_cat=testGalaxies(self.galaxy, obs_metadata=self.obs_metadata)
         test_cat.write_catalog("testGalaxiesOutput.txt")
         cat = open("testGalaxiesOutput.txt")


### PR DESCRIPTION
I discovered a bug in the sum_magnitudes method of PhotometryGalaxies.  If any one component (bulge, disk or agn) had NaN as its magnitude (because the galaxy did not have an SED associated with that component), the total magnitude for the galaxy was returned as NaN.

I have fixed that problem and added unit tests to make sure that sum_magnitudes works as expected.

This should be a quick review.  I would like to be able to incorporate this into an lsst_sims release tomorrow (Friday 6/19) evening.  If you can't look at it by then, it's not a big deal.  But I would really appreciate it if you could.

Thanks a ton,

Scott