### PR TITLE
Bugfix/sim 1214/cosmological dimming

### DIFF
--- a/python/lsst/sims/photUtils/CosmologyObject.py
+++ b/python/lsst/sims/photUtils/CosmologyObject.py
@@ -375,7 +375,10 @@ class CosmologyWrapper(object):
 
     NOTE: one should only include this mixin in catalogs whose magNorm is
     normalized to an absolute magnitude of some sort (i.e. the magnitude if
-    the galaxy was at redshift=0)
+    the galaxy was at redshift=0).  The magNorms for galaxies stored on the
+    University of Washington LSST database do not fit this criterion.
+    magNorms on the University of Washington LSST database include the
+    effects of cosmological distance modulus.
     """
 
     cosmology = CosmologyObject()

--- a/python/lsst/sims/photUtils/Photometry.py
+++ b/python/lsst/sims/photUtils/Photometry.py
@@ -529,6 +529,10 @@ class PhotometryGalaxies(PhotometryBase):
         componentMags = {}
 
         if cosmologicalDistanceModulus is None:
+            # if there is not a separate column for cosmologicalDistanceModulus,
+            # assume that magNorm includes the distance effects of redshift but
+            # not the additional 1/(1+z) dimming.  This is how magNorms
+            # on the University of Washington LSST database work.
             cosmologicalDimming = True
         else:
             cosmologicalDimming = False

--- a/python/lsst/sims/photUtils/utils/testUtils.py
+++ b/python/lsst/sims/photUtils/utils/testUtils.py
@@ -381,7 +381,10 @@ class cartoonPhotometryGalaxies(PhotometryGalaxies):
             redshift = self.column_by_name("redshift")
 
             sublist = self.loadSeds(sedNames, magNorm = magNormList)
-            self.applyAvAndRedshift(sublist, internalAv = Av, redshift = redshift)
+            if Av is not None:
+                self.applyAv(sublist, Av)
+
+            self.applyRedshift(sublist, redshift)
 
             for ss in sublist:
                 self.sedMasterDict[cc].append(ss)

--- a/tests/testCosmology.py
+++ b/tests/testCosmology.py
@@ -26,6 +26,13 @@ class absoluteGalaxyCatalog(testGalaxies):
                       'redshift']
 
 
+    def get_cosmologicalDistanceModulus(self):
+        """
+        Must set this to zero rather than `None` so that PhotometryGalaxies
+        does not apply cosmological dimming
+        """
+        return numpy.zeros(len(self.column_by_name('galid')))
+
 
 class CosmologyUnitTest(unittest.TestCase):
 


### PR DESCRIPTION
This should be a quick review.

I had been assuming that magNorm for galaxy components accounted for cosmological dimming.  Comparison to the magnitudes stored on fatboy indicated that this was not the case.  I have fixed PhotometryGalaxies so that it turns on cosmological dimming when it calls Sed.redshiftSED()

I acknowledge that this branch still does not treat dust absolutely correctly (I should allow Rv to vary between galaxies).  I have opened a ticket SIM-1216 to deal with this in the future.

There is a SIM-1214 pull request on sims_catUtils which brings unit tests in line with the changes made on this branch.