### PR TITLE
relative imports and basic init available

### DIFF
--- a/python/lsst/sims/photUtils/Bandpass.py
+++ b/python/lsst/sims/photUtils/Bandpass.py
@@ -61,7 +61,7 @@ import warnings
 import numpy
 import scipy.interpolate as interpolate
 import gzip
-from lsst.sims.photUtils import PhysicalParameters
+from .PhysicalParameters import PhysicalParameters
 from .Sed import Sed  # For ZP_t and M5 calculations. And for 'fast mags' calculation.
 
 __all__ = ["Bandpass"]

--- a/python/lsst/sims/photUtils/BandpassDict.py
+++ b/python/lsst/sims/photUtils/BandpassDict.py
@@ -3,7 +3,8 @@ import numpy
 import os
 from lsst.utils import getPackageDir
 from collections import OrderedDict
-from lsst.sims.photUtils import Bandpass, Sed
+from .Bandpass import Bandpass
+from .Sed import Sed
 
 __all__ = ["BandpassDict"]
 

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -85,7 +85,8 @@ import warnings
 import numpy
 import scipy.interpolate as interpolate
 import gzip
-from lsst.sims.photUtils import LSSTdefaults, PhysicalParameters
+from .LSSTdefaults import LSSTdefaults
+from .PhysicalParameters import PhysicalParameters
 
 __all__ = ["Sed"]
 

--- a/python/lsst/sims/photUtils/SedList.py
+++ b/python/lsst/sims/photUtils/SedList.py
@@ -3,7 +3,8 @@ import copy
 import numpy
 from lsst.utils import getPackageDir
 from lsst.sims.utils import defaultSpecMap
-from lsst.sims.photUtils import Bandpass, Sed
+from .Bandpass import Bandpass
+from .Sed import Sed
 
 __all__ = ["SedList"]
 

--- a/python/lsst/sims/photUtils/SignalToNoise.py
+++ b/python/lsst/sims/photUtils/SignalToNoise.py
@@ -1,7 +1,7 @@
 import numpy
 from .Sed import Sed
 from .Bandpass import Bandpass
-from lsst.sims.photUtils import LSSTdefaults
+import LSSTdefaults
 
 __all__ = ["calcNeff", "calcInstrNoiseSq", "calcTotalNonSourceNoiseSq", "calcSNR_sed",
           "calcM5", "calcSkyCountsPerPixelForM5", "calcGamma", "calcSNR_m5",

--- a/python/lsst/sims/photUtils/applyIGM.py
+++ b/python/lsst/sims/photUtils/applyIGM.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 import warnings
-from lsst.sims.photUtils.Sed import Sed
+from .Sed import Sed
 
 __all__ = ["ApplyIGM"]
 

--- a/python/lsst/sims/photUtils/basic__init__.py
+++ b/python/lsst/sims/photUtils/basic__init__.py
@@ -1,0 +1,6 @@
+from .LSSTdefaults import *
+from .PhysicalParameters import *
+from .Sed import *
+from .Bandpass import * 
+from .PhotometricParameters import *
+from .SignalToNoise import *

--- a/python/lsst/sims/photUtils/matchUtils.py
+++ b/python/lsst/sims/photUtils/matchUtils.py
@@ -8,9 +8,9 @@ import numpy as np
 import os
 import re
 
+from .Sed import Sed
+from .Bandpass import Bandpass
 import lsst.utils
-from lsst.sims.photUtils.Sed import Sed
-from lsst.sims.photUtils.Bandpass import Bandpass
 from lsst.sims.utils import SpecMap
 
 __all__ = ["matchBase", "matchStar", "matchGalaxy"]

--- a/python/lsst/sims/photUtils/selectGalaxySED.py
+++ b/python/lsst/sims/photUtils/selectGalaxySED.py
@@ -2,10 +2,10 @@ import os
 import numpy as np
 
 import lsst.utils
-from lsst.sims.photUtils.Sed import Sed
-from lsst.sims.photUtils.matchUtils import matchGalaxy
-from lsst.sims.photUtils import BandpassDict
-from lsst.sims.photUtils.EBV import EBVbase as ebv
+from .Sed import Sed
+from .matchUtils import matchGalaxy
+from .BandpassDict import BandpassDict
+from .EBV import EBVbase as ebv
 
 __all__ = ["selectGalaxySED"]
 

--- a/python/lsst/sims/photUtils/selectStarSED.py
+++ b/python/lsst/sims/photUtils/selectStarSED.py
@@ -3,9 +3,9 @@ import numpy as np
 import warnings
 
 import lsst.utils
-from lsst.sims.photUtils.matchUtils import matchStar
-from lsst.sims.photUtils import BandpassDict
-from lsst.sims.photUtils.EBV import EBVbase as ebv
+from .matchUtils import matchStar
+from .BandpassDict import BandpassDict
+from .EBV import EBVbase as ebv
 
 __all__ = ["selectStarSED"]
 


### PR DESCRIPTION
Swaps full package imports for relative imports and adds a basic__init__.py file that could be swapped for the __init__.py file to allow users to use photutils as a *completely* stand-alone package (they would just then add the directory to their PYTHONPATH). 