### PR TITLE
Updated write methods on Bandpass and Sed to make nicer output

### DIFF
--- a/python/lsst/sims/photUtils/Bandpass.py
+++ b/python/lsst/sims/photUtils/Bandpass.py
@@ -457,7 +457,9 @@ class Bandpass:
         f = open(filename, 'w')
         # Print header.
         if print_header is not None:
-            print >>f, "#", print_header
+            if not print_header.startswith('#'):
+                print_header = '#' + print_header
+            f.write(print_header)
         if write_phi:
             if self.phi is None:
                 self.sbTophi()

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -953,7 +953,9 @@ class Sed(object):
         # Then just use this gridded wavelen/flambda to calculate fnu.
         # Print header.
         if print_header is not None:
-            print >>f, "#", print_header
+            if not print_header.startswith('#'):
+                print_header = '# ' + print_header
+            f.write(print_header)
         # Print standard header info.
         if print_fnu:
             wavelen, fnu = self.flambdaTofnu(wavelen, flambda)

--- a/tests/testBandpassDict.py
+++ b/tests/testBandpassDict.py
@@ -67,12 +67,12 @@ class BandpassDictTest(unittest.TestCase):
                 self.assertEqual(controlName, testName)
 
             for name, bp in zip(nameList, bpList):
-                numpy.testing.assert_array_almost_equal(bp.wavelen, testDict[name].wavelen, 19)
-                numpy.testing.assert_array_almost_equal(bp.sb, testDict[name].sb, 19)
+                numpy.testing.assert_array_almost_equal(bp.wavelen, testDict[name].wavelen, 10)
+                numpy.testing.assert_array_almost_equal(bp.sb, testDict[name].sb, 10)
 
             for bpControl, bpTest in zip(bpList, testDict.values()):
-                numpy.testing.assert_array_almost_equal(bpControl.wavelen, bpTest.wavelen, 19)
-                numpy.testing.assert_array_almost_equal(bpControl.sb, bpTest.sb, 19)
+                numpy.testing.assert_array_almost_equal(bpControl.wavelen, bpTest.wavelen, 10)
+                numpy.testing.assert_array_almost_equal(bpControl.sb, bpTest.sb, 10)
 
 
     def testWavelenMatch(self):


### PR DESCRIPTION
This was a minor change ot the write methods of Bandpass and Sed to make it easier to write multi-line header information (such as from the syseng_throughputs repo python/createThroughputsFiles.py). 

However, there is a unit test failing that doesn't seem related (at least at first glance) and I don't  understand why. Not sure if this a case of I don't understand the underlying class and its purpose, or if its' a case that the unit test should have more documentation. So .. I don't know if the problem is something going on in the unit test or because I have an updated version of the throughputs curves (see my PR in throughputs). 