### PR TITLE
Bugfix/sim 1742/pyfits3.4

### DIFF
--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -395,7 +395,8 @@ class Sed(object):
             # Check if the wavelength range desired and the wavelength range of the object overlap.
             # If there is any non-overlap, raise warning.
             if (wavelen.max() < wavelen_grid.max()) or (wavelen.min() > wavelen_grid.min()):
-                warnings.warn('There is an area of non-overlap between desired wavelength range (%.2f to %.2f) and sed %s (%.2f to %2.f)' % (wavelen_grid.min(), wavelen_grid.max(), self.name, wavelen.min(), wavelen.max()))
+                warnings.warn('There is an area of non-overlap between desired wavelength range (%.2f to %.2f) and sed %s (%.2f to %2.f)'
+                              % (wavelen_grid.min(), wavelen_grid.max(), self.name, wavelen.min(), wavelen.max()))
             # Do the interpolation of wavelen/flux onto grid. (type/len failures will die here).
             f = interpolate.interp1d(wavelen, flux, bounds_error=False, fill_value=numpy.NaN)
             flux_grid = f(wavelen_grid)

--- a/tests/testApplyIGM.py
+++ b/tests/testApplyIGM.py
@@ -1,5 +1,6 @@
 import numpy as np
 import unittest
+import lsst.utils.tests as utilsTests
 import warnings
 import os
 from lsst.sims.photUtils.Sed import Sed
@@ -88,9 +89,14 @@ class TestApplyIGM(unittest.TestCase):
         testSed.resampleSED(wavelen_match = testTable15Above300[:,0])
         np.testing.assert_allclose(testTable15Above300[:,1], testSed.flambda, 1e-4)
 
+def suite():
+    utilsTests.init()
+    suites = []
+    suites += unittest.makeSuite(TestApplyIGM)
+    return unittest.TestSuite(suites)
+
+def run(shouldExit = False):
+    utilsTests.run(suite(),shouldExit)
+
 if __name__ == "__main__":
-
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestApplyIGM)
-    unittest.TextTestRunner(verbosity=2).run(suite)
-
-    unittest.main()
+    run(True)

--- a/tests/testSed.py
+++ b/tests/testSed.py
@@ -10,6 +10,7 @@ from lsst.sims.photUtils import PhotometricParameters
 
 class TestSedWavelenLimits(unittest.TestCase):
     def setUp(self):
+        warnings.simplefilter('always')
         self.wmin = 500
         self.wmax = 1500
         self.bandpasswavelen = np.arange(self.wmin, self.wmax+.5, 1)


### PR DESCRIPTION
The problem is that pyfits3.4 was causing a warning to get raised.  The unit tests that were failing test for that exact same warning.  Because the warning module's default behavior is to suppress identical warnings, the warnings were not being raised when the unit tests expected them, causing the failure.

This pull requests sets the warnings filter to allow all warnings through, even repeats.