### PR TITLE
U/danielsf/cache size

### DIFF
--- a/cacheDir/.gitignore
+++ b/cacheDir/.gitignore
@@ -1,4 +1,0 @@
-*.p
-*.txt
-*.sav
-*.fits

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -383,7 +383,7 @@ def cache_LSST_seds(wavelen_min=None, wavelen_max=None):
                                                         wav <= wavelen_max))
             new_cache[file_name] = (wav[valid_dexes], fl[valid_dexes])
 
-            _global_lsst_sed_cache = new_cache
+        _global_lsst_sed_cache = new_cache
 
     return
 

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -316,7 +316,7 @@ def cache_LSST_seds(wavelen_min=None, wavelen_max=None):
 
     global _global_lsst_sed_cache
     try:
-        sed_cache_dir = os.path.join(getPackageDir('sims_photUtils'), 'cacheDir')
+        sed_cache_dir = os.path.join(getPackageDir('sims_sed_library'), 'lsst_sed_cache_dir')
         sed_cache_name = os.path.join('lsst_sed_cache_%d.p' % sys.version_info.major)
         sed_dir = getPackageDir('sims_sed_library')
 
@@ -324,6 +324,9 @@ def cache_LSST_seds(wavelen_min=None, wavelen_max=None):
         print("You did not install sims_photUtils with the full LSST simulations "
               "stack. You cannot generate and load the cache of LSST SEDs")
         return
+
+    if not os.path.exists(sed_cache_dir):
+        os.mkdir(sed_cache_dir)
 
     must_generate = False
     if not os.path.exists(os.path.join(sed_cache_dir, sed_cache_name)):

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -287,7 +287,7 @@ def _generate_sed_cache(cache_dir, cache_name):
     return cache
 
 
-def cache_LSST_seds():
+def cache_LSST_seds(wavelen_min=None, wavelen_max=None):
     """
     Read all of the SEDs in sims_sed_library into a dict.  Pickle the dict
     and store it in sims_photUtils/cacheDir/lsst_sed_cache.p for future use.
@@ -302,6 +302,16 @@ def cache_LSST_seds():
     Note: the dict of cached SEDs will take up about 5GB on disk.  Once loaded,
     the cache will take up about 1.5GB of memory.  The cache takes about 14 minutes
     to generate and about 51 seconds to load on a 2014 Mac Book Pro.
+
+    Parameters (optional)
+    ---------------------
+    wavelen_min a float
+
+    wavelen_max a float
+
+    if either of these are not None, then every SED in the cache will be
+    truncated to only include the wavelength range (in nm) between
+    min_wavelen and max_wavelen
     """
 
     global _global_lsst_sed_cache
@@ -355,6 +365,21 @@ def cache_LSST_seds():
         print("Cannot use cache of LSST SEDs")
         _global_lsst_sed_cache = None
         pass
+
+    if min_wavelen is not None or max_wavelen is not None:
+        if min_wavelen is None:
+            min_wavelen = 0.0
+        if max_wavelen is None:
+            max_wavelen = numpy.inf
+
+        new_cache = {}
+        for file_name in _global_lsst_sed_cache:
+            wav, fl = _global_lsst_sed_cache.pop(file_name)
+            valid_dexes = numpy.where(numpy.logical_and(wav >= wavelen_min,
+                                                        wav <= wavelen_max))
+            new_cache[file_name] = (wav[valid_dexes], fl[valid_dexes])
+
+            _global_lsst_sed_cache = new_cache
 
     return
 

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -311,7 +311,7 @@ def cache_LSST_seds(wavelen_min=None, wavelen_max=None):
 
     if either of these are not None, then every SED in the cache will be
     truncated to only include the wavelength range (in nm) between
-    min_wavelen and max_wavelen
+    wavelen_min and wavelen_max
     """
 
     global _global_lsst_sed_cache
@@ -369,11 +369,11 @@ def cache_LSST_seds(wavelen_min=None, wavelen_max=None):
         _global_lsst_sed_cache = None
         pass
 
-    if min_wavelen is not None or max_wavelen is not None:
-        if min_wavelen is None:
-            min_wavelen = 0.0
-        if max_wavelen is None:
-            max_wavelen = numpy.inf
+    if waveln_min is not None or wavelen_max is not None:
+        if wavelen_min is None:
+            wavelen_min = 0.0
+        if wavelen_max is None:
+            wavelen_max = numpy.inf
 
         new_cache = {}
         for file_name in _global_lsst_sed_cache:

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -376,7 +376,8 @@ def cache_LSST_seds(wavelen_min=None, wavelen_max=None):
             wavelen_max = numpy.inf
 
         new_cache = {}
-        for file_name in _global_lsst_sed_cache:
+        list_of_sed_names = list(_global_lsst_sed_cache.keys())
+        for file_name in list_of_sed_names:
             wav, fl = _global_lsst_sed_cache.pop(file_name)
             valid_dexes = numpy.where(numpy.logical_and(wav >= wavelen_min,
                                                         wav <= wavelen_max))

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -1432,7 +1432,7 @@ class Sed(object):
 def read_close_Kurucz(teff, feH, logg):
     """
     Check the cached Kurucz models and load the model closest to the input stellar parameters.
-    Parameters are matched in order of Teff, feH, and logg. 
+    Parameters are matched in order of Teff, feH, and logg.
 
     Parameters
     ----------

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -369,7 +369,7 @@ def cache_LSST_seds(wavelen_min=None, wavelen_max=None):
         _global_lsst_sed_cache = None
         pass
 
-    if waveln_min is not None or wavelen_max is not None:
+    if wavelen_min is not None or wavelen_max is not None:
         if wavelen_min is None:
             wavelen_min = 0.0
         if wavelen_max is None:

--- a/python/lsst/sims/photUtils/SedUtils.py
+++ b/python/lsst/sims/photUtils/SedUtils.py
@@ -36,6 +36,14 @@ def getImsimFluxNorm(sed, magmatch):
     if sed.fnu is None:
         sed.flambdaTofnu()
 
+    if (getImsimFluxNorm.imsim_wavelen < sed.wavelen.min() or
+        getImsimFluxNorm.imsim_wavelen > sed.wavelen.max()):
+
+        raise RuntimeError("Cannot normalize sed "
+                           "at wavelength of %e nm\n" % getImsimFluxNorm.imsim_wavelen
+                           + "The SED does not cover that wavelength\n"
+                           + "(Covers %e < lambda %e)" % (sed.wavelen.min(), sed.wavelen.max()))
+
     mag = -2.5*np.log10(np.interp(getImsimFluxNorm.imsim_wavelen, sed.wavelen, sed.fnu)) - sed.zp
     dmag = magmatch - mag
     return np.power(10, (-0.4*dmag))


### PR DESCRIPTION
This PR allows users to only cache LSST SEDs within a certain wavelength range, in case they have limited memory.

It also changes the location of the SED cache.  Previously, the SED cache lived in sims_photUtils.  This would force users to regenerate the cache (or move it) every time they installed a new version of sims_photUtils.  Now, the cache lives in sims_sed_library, which should change much less frequently than sims_photUtils.