### PR TITLE
Drop iterkeys() in SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3,5 +3,5 @@ import os
 from lsst.sconsUtils import scripts
 scripts.BasicSConstruct("sims_photUtils")
 base_env = Environment(ENV=os.environ)
-for key in os.environ.iterkeys():
+for key in os.environ:
     base_env = os.environ[key]


### PR DESCRIPTION
Not needed in python2 or python3.