### PR TITLE
Update readnoise to actually match LSE-30.

### DIFF
--- a/python/lsst/sims/photUtils/PhotometricParameters.py
+++ b/python/lsst/sims/photUtils/PhotometricParameters.py
@@ -53,7 +53,7 @@ class DefaultPhotometricParameters(object):
     gain = makeDict(gainADU)
 
     # electrons per pixel per exposure
-    readnoiseE = 8.5
+    readnoiseE = 8.8
     readnoise = makeDict(readnoiseE)
 
     # electrons per pixel per second

--- a/tests/testPhotometricParameters.py
+++ b/tests/testPhotometricParameters.py
@@ -90,7 +90,7 @@ class PhotometricParametersUnitTest(unittest.TestCase):
             self.assertAlmostEqual(photParams.effarea/(np.pi*(6.423*100/2.0)**2), 1.0, 7)
             self.assertAlmostEqual(photParams.gain, 2.3, 7)
             self.assertAlmostEqual(photParams.darkcurrent, 0.2, 7)
-            self.assertAlmostEqual(photParams.readnoise, 8.5, 7)
+            self.assertAlmostEqual(photParams.readnoise, 8.8, 7)
             self.assertAlmostEqual(photParams.othernoise, 0, 7)
             self.assertAlmostEqual(photParams.platescale, 0.2, 7)
             if bp not in ['u', 'z', 'y']:
@@ -110,7 +110,7 @@ class PhotometricParametersUnitTest(unittest.TestCase):
         self.assertAlmostEqual(photParams.effarea/(np.pi*(6.423*100/2.0)**2), 1.0, 7)
         self.assertAlmostEqual(photParams.gain, 2.3, 7)
         self.assertAlmostEqual(photParams.darkcurrent, 0.2, 7)
-        self.assertAlmostEqual(photParams.readnoise, 8.5, 7)
+        self.assertAlmostEqual(photParams.readnoise, 8.8, 7)
         self.assertAlmostEqual(photParams.othernoise, 0, 7)
         self.assertAlmostEqual(photParams.platescale, 0.2, 7)
         self.assertAlmostEqual(photParams.sigmaSys, 0.005, 7)


### PR DESCRIPTION
Hi Scott, so 8.8 is actually correct for readnoise, not 8.5. I made a mistake when I calculated this, as I did not realize that 'darkcurrent' was already the variance of the darkcurrent (and thus is not squared in the noise calculation). 
With this 8.8 value, we do actually match the LSE-30 requirement of 9 e/15s exposure and 12.7 e/visit.