### PR TITLE
Added flag to read gzip files as text

### DIFF
--- a/python/lsst/sims/photUtils/Bandpass.py
+++ b/python/lsst/sims/photUtils/Bandpass.py
@@ -201,7 +201,7 @@ class Bandpass(object):
         # Filename is single file, now try to open file and read data.
         try:
             if filename.endswith('.gz'):
-                f = gzip.open(filename, 'r')
+                f = gzip.open(filename, 'rt')
             else:
                 f = open(filename, 'r')
         except IOError:
@@ -209,7 +209,7 @@ class Bandpass(object):
                 if filename.endswith('.gz'):
                     f = open(filename[:-3], 'r')
                 else:
-                    f = gzip.open(filename+'.gz', 'r')
+                    f = gzip.open(filename+'.gz', 'rt')
             except IOError:
                 raise IOError('The throughput file %s does not exist' %(filename))
         # The throughput file should have wavelength(A), throughput(Sb) as first two columns.
@@ -241,7 +241,8 @@ class Bandpass(object):
         if self.needResample():
             self.resampleBandpass()
         if self.sb.sum() < 1e-300:
-            raise Exception("Bandpass data from %s has no throughput in desired grid range %f, %f" %(filename, wavelen_min, wavelen_max))
+            raise Exception("Bandpass data from %s has no throughput in "
+                            "desired grid range %f, %f" %(filename, wavelen_min, wavelen_max))
         return
 
     def readThroughputList(self, componentList=['detector.dat', 'lens1.dat',

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -596,7 +596,7 @@ class Sed(object):
         # Try to open the data file.
         try:
             if filename.endswith('.gz'):
-                f = gzip.open(filename, 'r')
+                f = gzip.open(filename, 'rt')
             else:
                 f = open(filename, 'r')
         # if the above fails, look for the file with and without the gz
@@ -605,7 +605,7 @@ class Sed(object):
                 if filename.endswith(".gz"):
                     f = open(filename[:-3], 'r')
                 else:
-                    f = gzip.open(filename+".gz", 'r')
+                    f = gzip.open(filename+".gz", 'rt')
             except IOError:
                 raise IOError("The throughput file %s does not exist" % (filename))
         # Read source SED from file - lambda, fnu should be first two columns in the file.


### PR DESCRIPTION
Passed jenkins, pretty minor changes. 

the 'rt' flag in gzip.open passes the result as text, rather than 'rb' which passes as bytes. It seems that in py3, 'r' defaulted to bytes.