### PR TITLE
U/danielsf/o donnell

### DIFF
--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -906,6 +906,18 @@ class Sed(object):
         This method sets up extinction due to the model of
         Cardelli, Clayton and Mathis 1989 (ApJ 345, 245)
         """
+        return self.setupCCM_ab(self, wavelen=wavelen)
+
+    def setupCCM_ab(self, wavelen=None):
+        """
+        Calculate a(x) and b(x) for CCM dust model. (x=1/wavelen).
+
+        If wavelen not specified, calculates a and b on the own object's wavelength grid.
+        Returns a(x) and b(x) can be common to many seds, wavelen is the same.
+
+        This method sets up extinction due to the model of
+        Cardelli, Clayton and Mathis 1989 (ApJ 345, 245)
+        """
         # This extinction law taken from Cardelli, Clayton and Mathis ApJ 1989.
         # The general form is A_l / A(V) = a(x) + b(x)/R_V  (where x=1/lambda in microns),
         # then different values for a(x) and b(x) depending on wavelength regime.

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -103,6 +103,11 @@ try:
 except:
     pass
 
+
+# since Python now suppresses DeprecationWarnings by default
+warnings.filterwarnings("default", category=DeprecationWarning, module='lsst.sims.photUtils.Sed')
+
+
 __all__ = ["Sed", "cache_LSST_seds", "read_close_Kurucz"]
 
 
@@ -907,8 +912,8 @@ class Sed(object):
         This method sets up extinction due to the model of
         Cardelli, Clayton and Mathis 1989 (ApJ 345, 245)
         """
-        #warnings.warn("Sed.setupCCMab is now deprecated in favor of Sed.setupCCM_ab",
-        #              DeprecationWarning)
+        warnings.warn("Sed.setupCCMab is now deprecated in favor of Sed.setupCCM_ab",
+                      DeprecationWarning)
 
         return self.setupCCM_ab(wavelen=wavelen)
 
@@ -1039,6 +1044,8 @@ class Sed(object):
 
         Specify any two of A_V, E(B-V) or R_V (=3.1 default).
         """
+        warnings.warn("Sed.addCCMDust is now deprecated in favor of Sed.addDust",
+                      DeprecationWarning)
         return self.addDust(a_x, b_x, A_v=A_v, ebv=ebv,
                             R_v=R_v, wavelen=wavelen, flambda=flambda)
 

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -67,8 +67,9 @@ Method include:
   resampleSED -- primarily internal use, but may be useful to user. Resamples SED onto specified grid.
   flambdaTofnu / fnuToflambda -- conversion methods, does not affect wavelen gridding.
   redshiftSED -- redshifts the SED, optionally adding dimmingx
-  setupODonnell_ab / setupCCMab / addDust -- separated into two components, so that a_x/b_x can be reused between SEDS
-if the wavelength range and grid is the same for each SED (calculate a_x/b_x with setupODonnell_ab).
+  (setupODonnell_ab or setupCCM_ab) / addDust -- separated into two components, so that a_x/b_x can be reused between SEDS
+if the wavelength range and grid is the same for each SED (calculate a_x/b_x with either setupODonnell_ab
+or setupCCM_ab).
   multiplySED -- multiply two SEDS together.
   calcADU / calcMag / calcFlux -- with a Bandpass, calculate the ADU/magnitude/flux of a SED.
   calcFluxNorm / multiplyFluxNorm -- handle fluxnorm parameters (from UW LSST database) properly.

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -904,7 +904,7 @@ class Sed(object):
         Returns a(x) and b(x) can be common to many seds, wavelen is the same.
 
         This method sets up extinction due to the model of
-        Cardelli, Clayton and Mathis ApJ 1989
+        Cardelli, Clayton and Mathis 1989 (ApJ 345, 245)
         """
         # This extinction law taken from Cardelli, Clayton and Mathis ApJ 1989.
         # The general form is A_l / A(V) = a(x) + b(x)/R_V  (where x=1/lambda in microns),

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -1035,7 +1035,8 @@ class Sed(object):
 
         Specify any two of A_V, E(B-V) or R_V (=3.1 default).
         """
-        self.addDust(a_x, b_x, A_v=A_v, ebv=ebv, R_v=R_v, wavelen=wavelen, flambda=flambda)
+        return self.addDust(a_x, b_x, A_v=A_v, ebv=ebv,
+                            R_v=R_v, wavelen=wavelen, flambda=flambda)
 
     def addDust(self, a_x, b_x, A_v=None, ebv=None, R_v=3.1, wavelen=None, flambda=None):
         """

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -67,8 +67,8 @@ Method include:
   resampleSED -- primarily internal use, but may be useful to user. Resamples SED onto specified grid.
   flambdaTofnu / fnuToflambda -- conversion methods, does not affect wavelen gridding.
   redshiftSED -- redshifts the SED, optionally adding dimmingx
-  setupCCMab / addCCMDust -- separated into two components, so that a_x/b_x can be reused between SEDS
-if the wavelength range and grid is the same for each SED (calculate a_x/b_x with setupCCMab).
+  setupODonnell_ab / addCCMDust -- separated into two components, so that a_x/b_x can be reused between SEDS
+if the wavelength range and grid is the same for each SED (calculate a_x/b_x with setupODonnell_ab).
   multiplySED -- multiply two SEDS together.
   calcADU / calcMag / calcFlux -- with a Bandpass, calculate the ADU/magnitude/flux of a SED.
   calcFluxNorm / multiplyFluxNorm -- handle fluxnorm parameters (from UW LSST database) properly.
@@ -896,14 +896,16 @@ class Sed(object):
             return
         return wavelen, flambda
 
-    def setupCCMab(self, wavelen=None):
+    def setupODonnell_ab(self, wavelen=None):
         """
         Calculate a(x) and b(x) for CCM dust model. (x=1/wavelen).
 
         If wavelen not specified, calculates a and b on the own object's wavelength grid.
         Returns a(x) and b(x) can be common to many seds, wavelen is the same.
+
+        This method sets up the extinction parameters from the model of ODonnel 1994
+        (ApJ 422, 158)
         """
-        # This extinction law taken from Cardelli, Clayton and Mathis ApJ 1989.
         # The general form is A_l / A(V) = a(x) + b(x)/R_V  (where x=1/lambda in microns),
         # then different values for a(x) and b(x) depending on wavelength regime.
         # Also, the extinction is parametrized as R_v = A_v / E(B-V).

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -1017,7 +1017,19 @@ class Sed(object):
 
     def addCCMDust(self, a_x, b_x, A_v=None, ebv=None, R_v=3.1, wavelen=None, flambda=None):
         """
-        Add CCM dust model extinction to the SED, modifying flambda and fnu.
+        Add dust model extinction to the SED, modifying flambda and fnu.
+
+        Get a_x and b_x either from setupCCMab or setupODonnell_ab
+
+        Specify any two of A_V, E(B-V) or R_V (=3.1 default).
+        """
+        self.addDust(a_x, b_x, A_v=A_v, ebv=ebv, R_v=R_v, wavelen=wavelen, flambda=flambda)
+
+    def addDust(self, a_x, b_x, A_v=None, ebv=None, R_v=3.1, wavelen=None, flambda=None):
+        """
+        Add dust model extinction to the SED, modifying flambda and fnu.
+
+        Get a_x and b_x either from setupCCMab or setupODonnell_ab
 
         Specify any two of A_V, E(B-V) or R_V (=3.1 default).
         """

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -958,12 +958,12 @@ class Sed(object):
 
     def setupODonnell_ab(self, wavelen=None):
         """
-        Calculate a(x) and b(x) for CCM dust model. (x=1/wavelen).
+        Calculate a(x) and b(x) for O'Donnell dust model. (x=1/wavelen).
 
         If wavelen not specified, calculates a and b on the own object's wavelength grid.
         Returns a(x) and b(x) can be common to many seds, wavelen is the same.
 
-        This method sets up the extinction parameters from the model of ODonnel 1994
+        This method sets up the extinction parameters from the model of O'Donnel 1994
         (ApJ 422, 158)
         """
         # The general form is A_l / A(V) = a(x) + b(x)/R_V  (where x=1/lambda in microns),

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -907,7 +907,10 @@ class Sed(object):
         This method sets up extinction due to the model of
         Cardelli, Clayton and Mathis 1989 (ApJ 345, 245)
         """
-        return self.setupCCM_ab(self, wavelen=wavelen)
+        #warnings.warn("Sed.setupCCMab is now deprecated in favor of Sed.setupCCM_ab",
+        #              DeprecationWarning)
+
+        return self.setupCCM_ab(wavelen=wavelen)
 
     def setupCCM_ab(self, wavelen=None):
         """

--- a/python/lsst/sims/photUtils/Sed.py
+++ b/python/lsst/sims/photUtils/Sed.py
@@ -67,7 +67,7 @@ Method include:
   resampleSED -- primarily internal use, but may be useful to user. Resamples SED onto specified grid.
   flambdaTofnu / fnuToflambda -- conversion methods, does not affect wavelen gridding.
   redshiftSED -- redshifts the SED, optionally adding dimmingx
-  setupODonnell_ab / addCCMDust -- separated into two components, so that a_x/b_x can be reused between SEDS
+  setupODonnell_ab / setupCCMab / addDust -- separated into two components, so that a_x/b_x can be reused between SEDS
 if the wavelength range and grid is the same for each SED (calculate a_x/b_x with setupODonnell_ab).
   multiplySED -- multiply two SEDS together.
   calcADU / calcMag / calcFlux -- with a Bandpass, calculate the ADU/magnitude/flux of a SED.


### PR DESCRIPTION
I think DESC is approaching a point where the fact that PhoSim is using the Cardelli, Clayton, and Mathis dust model, but CatSim uses the ODonnell dust model is going to cause difficulties.  This PR restores the CCM parameters in the `setupCCMab` method and adds a `setupODonnell_ab` method to use the ODonnell dust model.